### PR TITLE
feat: add `BorrowCodec` and related content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          components: rustfmt, clippy
+          components: rustfmt, clippy, miri
       - name: setup cache
         id: cache
         uses: actions/cache@v4
@@ -42,6 +42,8 @@ jobs:
         run: cargo hack check --feature-powerset --skip serde,macros,full-codecs,default --no-dev-deps --at-least-one-of bincode,bitcode,json,msgpack,toml,yaml --group-features json,msgpack,toml,yaml
       - name: cargo test
         run: cargo test
+      - name: cargo miri test --tests extract
+        run: cargo miri test
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "axum-codec-macros",
  "bincode",
  "bitcode",
+ "bytes",
  "ciborium",
  "mime",
  "rmp-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ validator = { version = "0.19", optional = true }
 axum = "0.7"
 serde = { version = "1", features = ["derive", "rc"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-axum-codec = { path = ".", features = ["full-codecs", "macros"] }
-bitcode = "0.6"
+# cannot run `BorrowCodec` tests with `bitcode` since it doesn't support `Cow` (yet)
+axum-codec = { path = ".", features = ["json", "bincode", "msgpack", "toml", "yaml", "macros"] }
+bitcode = "0.6.3"
 
 [features]
 default = ["json", "macros", "pretty-errors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ axum-codec-macros = { path = "macros", version = "0.0.11", default-features = fa
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["std"], optional = true }
 # 0.6.3 added the #[bitcode(crate = "...")] option
 bitcode = { version = "0.6.3", default-features = false, features = ["std"], optional = true }
+bytes = "1"
 ciborium = { version = "0.2", optional = true }
 mime = "0.3"
 rmp-serde = { version= "1", optional = true }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 axum = "0.7"
 serde = { version = "1", features = ["derive", "rc"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-axum-codec = { path = "../..", features = ["full-codecs", "macros", "validator"] }
+axum-codec = { path = "../..", features = ["macros", "validator", "json", "bincode", "msgpack", "toml", "yaml"] }
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -46,15 +46,14 @@ struct BorrowGreeting<'d> {
 }
 
 async fn borrow_greet(greeting: BorrowCodec<BorrowGreeting<'_>>) -> impl IntoCodecResponse {
-	let is_zero = matches!(greeting.message, Cow::Borrowed(..));
+	let is_borrowed = matches!(greeting.message, Cow::Borrowed(..));
 
 	Codec(Greeting {
-		message: if is_zero {
-			"Borrowing from input"
+		message: if is_borrowed {
+			"Message is borrowed".into()
 		} else {
-			"Not borrowing from input (for JSON, probably using an escaped character)"
+			"Message is owned".into()
 		}
-		.to_string(),
 	})
 }
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,10 +1,13 @@
+use std::borrow::Cow;
+
 use axum::{
 	extract::{DefaultBodyLimit, State},
+	response::Response,
 	Router,
 };
 use axum_codec::{
 	routing::{get, post},
-	Codec, IntoCodecResponse,
+	Accept, BorrowCodec, Codec, CodecRejection, IntoCodecResponse,
 };
 
 #[axum_codec::apply(encode, decode)]
@@ -37,11 +40,38 @@ async fn state(State(state): State<String>) -> Codec<Greeting> {
 	Codec(Greeting { message: state })
 }
 
+#[axum_codec::apply(encode, decode)]
+struct BorrowGreeting<'d> {
+	#[serde(borrow)]
+	message: Cow<'d, str>,
+}
+
+async fn borrow_greet(
+	accept: Accept,
+	greeting: BorrowCodec<BorrowGreeting<'_>>,
+) -> Result<Response, CodecRejection> {
+	let greeting = greeting.decode()?;
+	let is_zero = matches!(greeting.message, Cow::Borrowed(..));
+
+	Ok(
+		Codec(Greeting {
+			message: if is_zero {
+				"Borrowing from input"
+			} else {
+				"Not borrowing from input (for JSON, probably using an escaped character)"
+			}
+			.to_string(),
+		})
+		.into_codec_response(accept.into()),
+	)
+}
+
 #[tokio::main]
 async fn main() {
 	let app = Router::new()
 		.route("/me", get(me).into())
 		.route("/greet", post(greet).into())
+		.route("/borrow-greet", post(borrow_greet).into())
 		.route("/state", get(state).into())
 		.layer(DefaultBodyLimit::max(1024))
 		.with_state("Hello, world!".to_string());

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -2,12 +2,11 @@ use std::borrow::Cow;
 
 use axum::{
 	extract::{DefaultBodyLimit, State},
-	response::Response,
 	Router,
 };
 use axum_codec::{
 	routing::{get, post},
-	Accept, BorrowCodec, Codec, CodecRejection, IntoCodecResponse,
+	BorrowCodec, Codec, IntoCodecResponse,
 };
 
 #[axum_codec::apply(encode, decode)]
@@ -46,24 +45,17 @@ struct BorrowGreeting<'d> {
 	message: Cow<'d, str>,
 }
 
-async fn borrow_greet(
-	accept: Accept,
-	greeting: BorrowCodec<BorrowGreeting<'_>>,
-) -> Result<Response, CodecRejection> {
-	let greeting = greeting.decode()?;
+async fn borrow_greet(greeting: BorrowCodec<BorrowGreeting<'_>>) -> impl IntoCodecResponse {
 	let is_zero = matches!(greeting.message, Cow::Borrowed(..));
 
-	Ok(
-		Codec(Greeting {
-			message: if is_zero {
-				"Borrowing from input"
-			} else {
-				"Not borrowing from input (for JSON, probably using an escaped character)"
-			}
-			.to_string(),
-		})
-		.into_codec_response(accept.into()),
-	)
+	Codec(Greeting {
+		message: if is_zero {
+			"Borrowing from input"
+		} else {
+			"Not borrowing from input (for JSON, probably using an escaped character)"
+		}
+		.to_string(),
+	})
 }
 
 #[tokio::main]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -147,6 +147,9 @@ mod __private {
 
 		codec_trait.extend(quote! {
 			#input
+			#[diagnostic::on_unimplemented(
+				note = "If you're looking for a zero-copy extractor, use `BorrowCodec`"
+			)]
 			pub trait CodecDecode<'de>
 		});
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,7 +1,7 @@
-use core::fmt;
-use std::{
-	marker::PhantomData,
+use core::{
+	fmt,
 	ops::{Deref, DerefMut},
+	pin::Pin,
 };
 
 use axum::{
@@ -175,53 +175,141 @@ where
 	}
 }
 
+/// Zero-copy codec extractor.
+///
+/// Similar to [`Codec`] in that it can decode from various formats,
+/// but different in that the backing bytes are kept alive after decoding
+/// and it cannot be used as a response encoder.
+///
+/// # Examples
+///
+/// ```edition2021
+/// # use axum_codec::{BorrowCodec, ContentType};
+/// # use axum::response::Response;
+/// # use std::borrow::Cow;
+/// #
+/// # fn main() {
+/// #[axum_codec::apply(decode)]
+/// struct Greeting<'d> {
+///   hello: Cow<'d, [u8]>,
+/// }
+///
+/// async fn my_route(body: BorrowCodec<Greeting<'_>>) -> Result<(), Response> {
+///   // do something with `body.hello`...
+///   println!("{:?}", body.hello);
+///
+///   Ok(())
+/// }
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// See [`CodecRejection`] for more information.
 pub struct BorrowCodec<T> {
-	bytes: Bytes,
-	content_type: ContentType,
-	_marker: PhantomData<T>,
+	data: T,
+	#[allow(dead_code)]
+	#[doc(hidden)]
+	bytes: Pin<Bytes>,
 }
 
-impl<T> BorrowCodec<T> {
-	/// Zero-copy codec extractor.
-	///
-	/// Similar to [`Codec`] in that it can decode from various formats,
-	/// but different in that the backing bytes are kept alive after decoding
-	/// and it cannot be used as a response encoder.
-	///
-	/// # Examples
-	///
-	/// ```edition2021
-	/// # use axum_codec::{BorrowCodec, ContentType};
-	/// # use axum::response::Response;
-	/// # use std::borrow::Cow;
-	/// #
-	/// # fn main() {
-	/// #[axum_codec::apply(decode)]
-	/// struct Greeting {
-	///   hello: Cow<'d, [u8]>,
-	/// }
-	///
-	/// async fn my_route(body: BorrowCodec<Greeting>) -> Result<(), Response> {
-	///   let body = body.decode()?;
-	///
-	///   // do something with `body.hello`...
-	/// }
-	/// # }
-	/// ```
+impl<T> fmt::Debug for BorrowCodec<T>
+where
+	T: fmt::Debug,
+{
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("BorrowCodec")
+			.field("data", &self.data)
+			.finish_non_exhaustive()
+	}
+}
+
+impl<T> PartialEq for BorrowCodec<T>
+where
+	T: PartialEq,
+{
+	fn eq(&self, other: &Self) -> bool {
+		self.data == other.data
+	}
+}
+
+impl<T> Eq for BorrowCodec<T> where T: Eq {}
+
+impl<T> PartialOrd for BorrowCodec<T>
+where
+	T: PartialOrd,
+{
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		self.data.partial_cmp(&other.data)
+	}
+}
+
+impl<T> Ord for BorrowCodec<T>
+where
+	T: Ord,
+{
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		self.data.cmp(&other.data)
+	}
+}
+
+impl<T> std::hash::Hash for BorrowCodec<T>
+where
+	T: std::hash::Hash,
+{
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		self.data.hash(state);
+	}
+}
+
+impl<T> Default for BorrowCodec<T>
+where
+	T: Default,
+{
+	fn default() -> Self {
+		Self {
+			data: Default::default(),
+			bytes: Pin::new(Bytes::new()),
+		}
+	}
+}
+
+impl<'de, T> BorrowCodec<T>
+where
+	T: CodecDecode<'de>,
+{
+	/// Creates a new [`BorrowCodec`] from the given bytes and content type.
 	///
 	/// # Errors
 	///
 	/// See [`CodecRejection`] for more information.
-	pub fn decode<'de, 's: 'de>(&'s self) -> Result<T, CodecRejection>
-	where
-		T: CodecDecode<'de>,
-	{
-		let data = Codec::<T>::from_bytes(&self.bytes, self.content_type)?;
+	pub fn from_bytes(bytes: Bytes, content_type: ContentType) -> Result<Self, CodecRejection> {
+		let bytes = Pin::new(bytes);
 
-		#[cfg(feature = "validator")]
-		data.validate()?;
+		Ok(Self {
+			data: Codec::<T>::from_bytes(
+				// SAFETY: The bytes that are being referenced by the slice are pinned
+				// and will not be dropped while the slice is alive.
+				unsafe { std::slice::from_raw_parts(bytes.as_ptr(), bytes.len()) },
+				content_type,
+			)?
+			.into_inner(),
+			bytes,
+		})
+	}
+}
 
-		Ok(data.into_inner())
+impl<T> Deref for BorrowCodec<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.data
+	}
+}
+
+impl<T> DerefMut for BorrowCodec<T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.data
 	}
 }
 
@@ -249,11 +337,15 @@ where
 			.await
 			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
 
-		Ok(Self {
-			bytes,
-			content_type,
-			_marker: PhantomData,
-		})
+		let data =
+			Self::from_bytes(bytes, content_type).map_err(|e| e.into_codec_response(accept.into()))?;
+
+		#[cfg(feature = "validator")]
+		data
+			.validate()
+			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
+
+		Ok(data)
 	}
 }
 
@@ -303,6 +395,46 @@ mod test {
 
 		assert_eq!(data, Data {
 			hello: "world".into()
+		});
+	}
+}
+
+#[cfg(any(test, miri))]
+mod miri {
+	use std::borrow::Cow;
+
+	use axum::body::Bytes;
+
+	use super::{BorrowCodec, ContentType};
+
+	#[crate::apply(decode, crate = "crate")]
+	#[derive(Debug, PartialEq, Eq)]
+	struct BorrowData<'a> {
+		#[serde(borrow)]
+		hello: Cow<'a, str>,
+	}
+
+	#[test]
+	fn test_zero_copy() {
+		let bytes = b"{\"hello\": \"world\"}".to_vec();
+		let data =
+			BorrowCodec::<BorrowData>::from_bytes(Bytes::from(bytes), ContentType::Json).unwrap();
+
+		assert_eq!(&*data, &BorrowData {
+			hello: Cow::Borrowed("world")
+		});
+	}
+
+	#[test]
+	fn test_zero_copy_mem_swap() {
+		let bytes = b"{\"hello\": \"world\"}".to_vec();
+		let mut data =
+			BorrowCodec::<BorrowData>::from_bytes(Bytes::from(bytes), ContentType::Json).unwrap();
+
+		core::mem::swap(&mut data.hello, &mut Cow::Borrowed("everyone"));
+
+		assert_eq!(&*data, &BorrowData {
+			hello: Cow::Borrowed("everyone")
 		});
 	}
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,15 +1,14 @@
 use core::{
 	fmt,
 	ops::{Deref, DerefMut},
-	pin::Pin,
 };
 
 use axum::{
-	body::Bytes,
 	extract::{FromRequest, FromRequestParts, Request},
 	http::header,
 	response::{IntoResponse, Response},
 };
+use bytes::BytesMut;
 
 use crate::{Accept, CodecDecode, CodecEncode, CodecRejection, ContentType, IntoCodecResponse};
 
@@ -116,7 +115,7 @@ where
 			.and_then(ContentType::from_header)
 			.unwrap_or_default();
 
-		let bytes = Bytes::from_request(req, state)
+		let bytes = BytesMut::from_request(req, state)
 			.await
 			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
 		let data =
@@ -181,6 +180,9 @@ where
 /// but different in that the backing bytes are kept alive after decoding
 /// and it cannot be used as a response encoder.
 ///
+/// Note that the decoded data cannot be modified, as it is borrowed.
+/// If you need to modify the data, use [`Codec`] instead.
+///
 /// # Examples
 ///
 /// ```edition2021
@@ -210,7 +212,34 @@ pub struct BorrowCodec<T> {
 	data: T,
 	#[allow(dead_code)]
 	#[doc(hidden)]
-	bytes: Pin<Bytes>,
+	bytes: BytesMut,
+}
+
+impl<T> BorrowCodec<T> {
+	/// Returns a mutable reference to the inner value.
+	///
+	/// # Safety
+	///
+	/// Callers must ensure that the inner value is not kept alive longer
+	/// than the original [`BorrowCodec`] that it came from. For example,
+	/// via [`std::mem::swap`] or [`std::mem::replace`].
+	pub unsafe fn as_mut_unchecked(&mut self) -> &mut T {
+		&mut self.data
+	}
+}
+
+impl<T> AsRef<T> for BorrowCodec<T> {
+	fn as_ref(&self) -> &T {
+		self
+	}
+}
+
+impl<T> Deref for BorrowCodec<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.data
+	}
 }
 
 impl<T> fmt::Debug for BorrowCodec<T>
@@ -262,18 +291,6 @@ where
 	}
 }
 
-impl<T> Default for BorrowCodec<T>
-where
-	T: Default,
-{
-	fn default() -> Self {
-		Self {
-			data: Default::default(),
-			bytes: Pin::new(Bytes::new()),
-		}
-	}
-}
-
 impl<'de, T> BorrowCodec<T>
 where
 	T: CodecDecode<'de>,
@@ -283,33 +300,21 @@ where
 	/// # Errors
 	///
 	/// See [`CodecRejection`] for more information.
-	pub fn from_bytes(bytes: Bytes, content_type: ContentType) -> Result<Self, CodecRejection> {
-		let bytes = Pin::new(bytes);
-
-		Ok(Self {
-			data: Codec::<T>::from_bytes(
-				// SAFETY: The bytes that are being referenced by the slice are pinned
-				// and will not be dropped while the slice is alive.
+	pub fn from_bytes(bytes: BytesMut, content_type: ContentType) -> Result<Self, CodecRejection> {
+		let data = Codec::<T>::from_bytes(
+				// SAFETY: The bytes that are being referenced by the slice are behind a pointer
+				// so they will not move. The bytes are also kept alive by the struct that contains
+				// this struct that references the slice, so the bytes will not be deallocated
+				// while this struct is alive.
 				unsafe { std::slice::from_raw_parts(bytes.as_ptr(), bytes.len()) },
 				content_type,
 			)?
-			.into_inner(),
+			.into_inner();
+
+		Ok(Self {
+			data,
 			bytes,
 		})
-	}
-}
-
-impl<T> Deref for BorrowCodec<T> {
-	type Target = T;
-
-	fn deref(&self) -> &Self::Target {
-		&self.data
-	}
-}
-
-impl<T> DerefMut for BorrowCodec<T> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.data
 	}
 }
 
@@ -333,7 +338,7 @@ where
 			.and_then(ContentType::from_header)
 			.unwrap_or_default();
 
-		let bytes = Bytes::from_request(req, state)
+		let bytes = BytesMut::from_request(req, state)
 			.await
 			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
 
@@ -342,6 +347,7 @@ where
 
 		#[cfg(feature = "validator")]
 		data
+			.as_ref()
 			.validate()
 			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
 
@@ -403,9 +409,9 @@ mod test {
 mod miri {
 	use std::borrow::Cow;
 
-	use axum::body::Bytes;
+	use bytes::Bytes;
 
-	use super::{BorrowCodec, ContentType};
+	use super::*;
 
 	#[crate::apply(decode, crate = "crate")]
 	#[derive(Debug, PartialEq, Eq)]
@@ -418,23 +424,8 @@ mod miri {
 	fn test_zero_copy() {
 		let bytes = b"{\"hello\": \"world\"}".to_vec();
 		let data =
-			BorrowCodec::<BorrowData>::from_bytes(Bytes::from(bytes), ContentType::Json).unwrap();
+			BorrowCodec::<BorrowData>::from_bytes(BytesMut::from(Bytes::from(bytes)), ContentType::Json).unwrap();
 
-		assert_eq!(&*data, &BorrowData {
-			hello: Cow::Borrowed("world")
-		});
-	}
-
-	#[test]
-	fn test_zero_copy_mem_swap() {
-		let bytes = b"{\"hello\": \"world\"}".to_vec();
-		let mut data =
-			BorrowCodec::<BorrowData>::from_bytes(Bytes::from(bytes), ContentType::Json).unwrap();
-
-		core::mem::swap(&mut data.hello, &mut Cow::Borrowed("everyone"));
-
-		assert_eq!(&*data, &BorrowData {
-			hello: Cow::Borrowed("everyone")
-		});
+		assert_eq!(data.hello, Cow::Borrowed("world"));
 	}
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,5 +1,8 @@
 use core::fmt;
-use std::ops::{Deref, DerefMut};
+use std::{
+	marker::PhantomData,
+	ops::{Deref, DerefMut},
+};
 
 use axum::{
 	body::Bytes,
@@ -47,15 +50,17 @@ use crate::{Accept, CodecDecode, CodecEncode, CodecRejection, ContentType, IntoC
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Codec<T>(pub T);
 
-impl<T> Codec<T>
-where
-	T: CodecEncode,
-{
+impl<T> Codec<T> {
 	/// Consumes the [`Codec`] and returns the inner value.
 	pub fn into_inner(self) -> T {
 		self.0
 	}
+}
 
+impl<T> Codec<T>
+where
+	T: CodecEncode,
+{
 	/// Converts the inner value into a response with the given content type.
 	///
 	/// If serialization fails, the rejection is converted into a response. See
@@ -167,6 +172,105 @@ where
 {
 	fn validate(&self) -> Result<(), validator::ValidationErrors> {
 		self.0.validate()
+	}
+}
+
+pub struct BorrowCodec<T> {
+	bytes: Bytes,
+	content_type: ContentType,
+	_marker: PhantomData<T>,
+}
+
+impl<T> BorrowCodec<T> {
+	/// Zero-copy codec extractor.
+	///
+	/// Similar to [`Codec`] in that it can decode from various formats,
+	/// but different in that the backing bytes are kept alive after decoding
+	/// and it cannot be used as a response encoder.
+	///
+	/// # Examples
+	///
+	/// ```edition2021
+	/// # use axum_codec::{BorrowCodec, ContentType};
+	/// # use axum::response::Response;
+	/// # use std::borrow::Cow;
+	/// #
+	/// # fn main() {
+	/// #[axum_codec::apply(decode)]
+	/// struct Greeting {
+	///   hello: Cow<'d, [u8]>,
+	/// }
+	///
+	/// async fn my_route(body: BorrowCodec<Greeting>) -> Result<(), Response> {
+	///   let body = body.decode()?;
+	///
+	///   // do something with `body.hello`...
+	/// }
+	/// # }
+	/// ```
+	///
+	/// # Errors
+	///
+	/// See [`CodecRejection`] for more information.
+	pub fn decode<'de, 's: 'de>(&'s self) -> Result<T, CodecRejection>
+	where
+		T: CodecDecode<'de>,
+	{
+		let data = Codec::<T>::from_bytes(&self.bytes, self.content_type)?;
+
+		#[cfg(feature = "validator")]
+		data.validate()?;
+
+		Ok(data.into_inner())
+	}
+}
+
+#[axum::async_trait]
+impl<T, S> FromRequest<S> for BorrowCodec<T>
+where
+	T: CodecDecode<'static>,
+	S: Send + Sync + 'static,
+{
+	type Rejection = Response;
+
+	async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+		let (mut parts, body) = req.into_parts();
+		let accept = Accept::from_request_parts(&mut parts, state).await.unwrap();
+
+		let req = Request::from_parts(parts, body);
+
+		let content_type = req
+			.headers()
+			.get(header::CONTENT_TYPE)
+			.and_then(ContentType::from_header)
+			.unwrap_or_default();
+
+		let bytes = Bytes::from_request(req, state)
+			.await
+			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
+
+		Ok(Self {
+			bytes,
+			content_type,
+			_marker: PhantomData,
+		})
+	}
+}
+
+#[cfg(feature = "aide")]
+impl<T> aide::operation::OperationInput for BorrowCodec<T>
+where
+	T: schemars::JsonSchema,
+{
+	fn operation_input(ctx: &mut aide::gen::GenContext, operation: &mut aide::openapi::Operation) {
+		axum::Json::<T>::operation_input(ctx, operation);
+	}
+
+	fn inferred_early_responses(
+		ctx: &mut aide::gen::GenContext,
+		operation: &mut aide::openapi::Operation,
+	) -> Vec<(Option<u16>, aide::openapi::Response)> {
+		axum::Json::<T>::inferred_early_responses(ctx, operation)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub mod routing;
 pub use content::{Accept, ContentType};
 pub use decode::CodecDecode;
 pub use encode::CodecEncode;
-pub use extract::Codec;
+pub use extract::{BorrowCodec, Codec};
 pub use handler::CodecHandler;
 pub use rejection::CodecRejection;
 pub use response::IntoCodecResponse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 #![cfg_attr(
@@ -13,7 +12,7 @@
 	)),
 	allow(unreachable_code, unused_variables)
 )]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(miri), doc = include_str!("../README.md"))]
 
 mod content;
 mod decode;
@@ -56,6 +55,8 @@ pub use macros::debug_middleware;
 
 #[cfg(test)]
 mod test {
+	use std::borrow::Cow;
+
 	use super::*;
 
 	#[apply(decode, encode)]
@@ -70,7 +71,7 @@ mod test {
 	#[apply(decode, encode)]
 	#[derive(Debug, PartialEq)]
 	struct BorrowedData<'a> {
-		string: &'a str,
+		string: Cow<'a, str>,
 		integer: i32,
 		boolean: bool,
 	}
@@ -86,7 +87,7 @@ mod test {
 
 	fn borrowed_data<'a>() -> BorrowedData<'a> {
 		BorrowedData {
-			string: "hello",
+			string: Cow::Borrowed("hello"),
 			integer: 42,
 			boolean: true,
 		}
@@ -103,7 +104,6 @@ mod test {
 	}
 
 	#[test]
-	#[should_panic(expected = "invalid type: string \\\"hello\\\", expected a borrowed string")]
 	fn test_borrowed_msgpack_roundtrip() {
 		let data = borrowed_data();
 		let encoded = Codec(&data).to_msgpack().unwrap();
@@ -186,7 +186,6 @@ mod test {
 	}
 
 	#[test]
-	#[should_panic(expected = "invalid type: string \\\"hello\\\", expected a borrowed string")]
 	fn test_borrowed_toml_roundtrip() {
 		let data = borrowed_data();
 		let encoded = Codec(&data).to_toml().unwrap();
@@ -217,6 +216,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "bitcode")]
 	fn test_bitcode_roundtrip() {
 		let encoded = Codec(data()).to_bitcode();
 
@@ -226,6 +226,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(feature = "bitcode")]
 	fn test_borrowed_bitcode_roundtrip() {
 		let encoded = Codec(borrowed_data()).to_bitcode();
 

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -80,7 +80,7 @@ macro_rules! method_router_chain_method {
 		#[must_use]
 		pub fn $name<T, H, I, D>(mut self, handler: H) -> Self
 		where
-			H: CodecHandler<T, I, D, S> + Clone + Send + Sync + 'static,
+			H: CodecHandler<T, I, D, S> + Clone + Send + 'static,
 			I: Input + Send + 'static,
 			D: IntoCodecResponse + Send + Sync + 'static,
 			S: Clone + Send + Sync + 'static,
@@ -99,7 +99,7 @@ macro_rules! method_router_chain_method {
 		#[must_use]
 		pub fn $name<T, H, I, D>(mut self, handler: H) -> Self
 		where
-			H: CodecHandler<T, I, D, S> + Clone + Send + Sync + 'static,
+			H: CodecHandler<T, I, D, S> + Clone + Send + 'static,
 			I: Input + Send + 'static,
 			D: IntoCodecResponse + Send + 'static,
 			S: Clone + Send + Sync + 'static,
@@ -113,7 +113,7 @@ macro_rules! method_router_chain_method {
 		#[must_use]
 		pub fn $with<T, H, I, D, F>(mut self, handler: H, transform: F) -> Self
 		where
-			H: CodecHandler<T, I, D, S> + Clone + Send + Sync + 'static,
+			H: CodecHandler<T, I, D, S> + Clone + Send + 'static,
 			I: Input + Send + 'static,
 			D: IntoCodecResponse + Send + 'static,
 			S: Clone + Send + Sync + 'static,
@@ -153,9 +153,9 @@ macro_rules! method_router_top_level {
 		#[doc = concat!("Route `", stringify!($name) ,"` requests to the given handler. See [`axum::routing::", stringify!($name) , "`] for more details.")]
 		pub fn $name<T, H, I, D, S>(handler: H) -> MethodRouter<S, Infallible>
 		where
-			H: CodecHandler<T, I, D, S> + Clone + Send + Sync + 'static,
+			H: CodecHandler<T, I, D, S> + Clone + Send + 'static,
 			I: Input + Send + 'static,
-			D: IntoCodecResponse + Send + Sync + 'static,
+			D: IntoCodecResponse + Send + 'static,
 			S: Clone + Send + Sync + 'static,
 			T: 'static
 		{
@@ -170,7 +170,7 @@ macro_rules! method_router_top_level {
 		#[doc = concat!("Route `", stringify!($name) ,"` requests to the given handler. See [`axum::routing::", stringify!($name) , "`] for more details.")]
 		pub fn $name<T, H, I, D, S>(handler: H) -> MethodRouter<S, Infallible>
 		where
-			H: CodecHandler<T, I, D, S> + Clone + Send + Sync + 'static,
+			H: CodecHandler<T, I, D, S> + Clone + Send + 'static,
 			I: Input + Send + 'static,
 			D: IntoCodecResponse + Send + 'static,
 			S: Clone + Send + Sync + 'static,
@@ -185,9 +185,9 @@ macro_rules! method_router_top_level {
 		#[must_use]
 		pub fn $with<T, H, I, D, S, F>(handler: H, transform: F) -> MethodRouter<S, Infallible>
 		where
-			H: CodecHandler<T, I, D, S> + Clone + Send + Sync + 'static,
+			H: CodecHandler<T, I, D, S> + Clone + Send + 'static,
 			I: Input + Send + 'static,
-			D: IntoCodecResponse + Send + Sync + 'static,
+			D: IntoCodecResponse + Send + 'static,
 			S: Clone + Send + Sync + 'static,
 			T: 'static,
 			F: FnOnce(aide::transform::TransformOperation) -> aide::transform::TransformOperation,


### PR DESCRIPTION
Resolves #4 

This design followed closely axum's [`JsonDeserializer`](https://docs.rs/axum-extra/latest/axum_extra/extract/struct.JsonDeserializer.html). I don't like how error handling has to be moved into the route implementation (i.e. `body.decode()?` instead of simply only having it as a param like `Codec`), but AFAIK the decoded data cannot reference the bytes stored in the same struct (without `Pin` or something similar, which might be annoying for users to work around). [ouroboros](https://github.com/someguynamedjosh/ouroboros) seems pretty limiting from what I can tell, I think it can only be used as a "getter" and doesn't actually hold the reference anywhere?

Anyway, I'll probably come back to this if there's a nicer way that can keep it all contained in the extractor.