### PR TITLE
feat: add form support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - 'README.md' # it's included in the crate root
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 name: ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
         run: cargo install cargo-hack --locked
 
       - name: cargo hack
-        #        run: cargo hack check --feature-powerset --skip serde,macros,full-codecs,default --no-dev-deps --at-least-one-of bincode,bitcode,cbor,json,msgpack,toml,yaml --group-features cbor,json,msgpack,toml,yaml
-        run: cargo hack check --feature-powerset --skip serde,macros,full-codecs,default --no-dev-deps --at-least-one-of bincode,bitcode,json,msgpack,toml,yaml --group-features json,msgpack,toml,yaml
+        #        run: cargo hack check --feature-powerset --skip serde,macros,full-codecs,default --no-dev-deps --at-least-one-of bincode,bitcode,cbor,json,msgpack,toml,yaml,form --group-features cbor,json,msgpack,toml,yaml,form
+        run: cargo hack check --feature-powerset --skip serde,macros,full-codecs,default --no-dev-deps --at-least-one-of bincode,bitcode,json,msgpack,toml,yaml,form --group-features json,msgpack,toml,yaml,form
       - name: cargo test
         run: cargo test
       - name: cargo miri test --tests extract

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_yaml",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rmp-serde = { version= "1", optional = true }
 schemars = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true }
+serde_urlencoded = { version = "0.7", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 thiserror = "1"
 toml = { version = "0.8", optional = true }
@@ -37,14 +38,14 @@ axum = "0.7"
 serde = { version = "1", features = ["derive", "rc"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 # cannot run `BorrowCodec` tests with `bitcode` since it doesn't support `Cow` (yet)
-axum-codec = { path = ".", features = ["json", "bincode", "msgpack", "toml", "yaml", "macros"] }
+axum-codec = { path = ".", features = ["json", "bincode", "msgpack", "toml", "yaml", "macros", "form"] }
 bitcode = "0.6.3"
 
 [features]
 default = ["json", "macros", "pretty-errors"]
 
 # Enables all codecs
-full-codecs = ["bincode", "bitcode", "json", "msgpack", "toml", "yaml"]
+full-codecs = ["bincode", "bitcode", "json", "msgpack", "toml", "yaml", "form"]
 macros = ["schemars?/derive", "bincode?/derive", "bitcode?/derive", "serde?/derive", "validator?/derive", "axum-codec-macros/debug"]
 
 # Enables support for {get,put,..}_with and relevant chaning methods
@@ -58,6 +59,7 @@ validator = ["dep:validator", "axum-codec-macros/validator"]
 # improves the quality of error messages for consumers of the API.
 pretty-errors = ["macros"]
 
+form = ["dep:serde_urlencoded", "axum/form"]
 bincode = ["dep:bincode", "axum-codec-macros/bincode"]
 bitcode = ["dep:bitcode", "axum-codec-macros/bitcode"]
 # cbor = ["dep:ciborium", "serde"]
@@ -68,6 +70,7 @@ yaml = ["dep:serde_yaml", "serde"]
 
 # Should not be manually enabled, but will not cause any issues if it is.
 serde = ["dep:serde", "axum-codec-macros/serde"]
+serde_urlencoded = ["dep:serde_urlencoded"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cbor"))'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ yaml = ["dep:serde_yaml", "serde"]
 
 # Should not be manually enabled, but will not cause any issues if it is.
 serde = ["dep:serde", "axum-codec-macros/serde"]
-serde_urlencoded = ["dep:serde_urlencoded"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cbor"))'] }

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ async fn main() {
 
 - `macros`: Enables the `axum_codec::apply` attribute macro.
 - `json`\*: Enables [`JSON`](https://github.com/serde-rs/json) support.
+- `form`: Enables [`x-www-form-urlencoded`](https://github.com/nox/serde_urlencoded) support.
 - `msgpack`: Enables [`MessagePack`](https://github.com/3Hren/msgpack-rust) support.
 - `bincode`: Enables [`Bincode`](https://github.com/bincode-org/bincode) support.
 - `bitcode`: Enables [`Bitcode`](https://github.com/SoftbearStudios/bitcode) support.
-- `cbor`: Enables [`CBOR`](https://github.com/enarx/ciborium) support.
 - `yaml`: Enables [`YAML`](https://github.com/dtolnay/serde-yaml/releases) support.
 - `toml`: Enables [`TOML`](https://github.com/toml-rs/toml) support.
 - `aide`: Enables support for the [`Aide`](https://github.com/tamasfe/aide) documentation library.
@@ -106,6 +106,10 @@ async fn main() {
 
 Since `axum-codec` uses its own `IntoCodecResponse` trait for encoding responses, it is not compatible with `#[axum::debug_handler]`. However, a new `#[axum_codec::debug_handler]` (and `#[axum_codec::debug_middleware]`) macro
 is provided as a drop-in replacement.
+
+## Roadmap
+
+- [ ] Add `codec!` macro for defining custom codecs that use a different subset of enabled formats.
 
 ## License
 

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 axum = "0.7"
 serde = { version = "1", features = ["derive", "rc"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-axum-codec = { path = "../..", features = ["macros", "validator", "json", "bincode", "msgpack", "toml", "yaml"] }
+axum-codec = { path = "../..", features = ["macros", "validator", "json", "bincode", "msgpack", "toml", "yaml", "form"] }
 

--- a/src/content.rs
+++ b/src/content.rs
@@ -11,6 +11,8 @@ use axum::{
 pub enum ContentType {
 	#[cfg(feature = "json")]
 	Json,
+	#[cfg(feature = "form")]
+	Form,
 	#[cfg(feature = "msgpack")]
 	MsgPack,
 	#[cfg(feature = "bincode")]
@@ -27,6 +29,7 @@ pub enum ContentType {
 
 #[cfg(not(any(
 	feature = "json",
+	feature = "form",
 	feature = "msgpack",
 	feature = "bincode",
 	feature = "bitcode",
@@ -36,19 +39,20 @@ pub enum ContentType {
 )))]
 const _: () = {
 	compile_error!(
-		"At least one of the following features must be enabled: `json`, `msgpack`, `bincode`, \
-		 `bitcode`, `cbor`, `yaml`, `toml`."
+		"At least one of the following features must be enabled: `json`, `form`, `msgpack`, \
+		 `bincode`, `bitcode`, `cbor`, `yaml`, `toml`."
 	);
 
 	impl Default for ContentType {
 		fn default() -> Self {
-			unreachable!()
+			unimplemented!()
 		}
 	}
 };
 
 #[cfg(any(
 	feature = "json",
+	feature = "form",
 	feature = "msgpack",
 	feature = "bincode",
 	feature = "bitcode",
@@ -61,6 +65,8 @@ impl Default for ContentType {
 	fn default() -> Self {
 		#[cfg(feature = "json")]
 		return Self::Json;
+		#[cfg(feature = "form")]
+		return Self::Form;
 		#[cfg(feature = "msgpack")]
 		return Self::MsgPack;
 		#[cfg(feature = "bincode")]
@@ -100,6 +106,8 @@ impl FromStr for ContentType {
 		Ok(match (mime.type_().as_str(), subtype.as_str()) {
 			#[cfg(feature = "json")]
 			("application", "json") => Self::Json,
+			#[cfg(feature = "form")]
+			("application", "x-www-form-urlencoded") => Self::Form,
 			#[cfg(feature = "msgpack")]
 			("application", "msgpack" | "vnd.msgpack" | "x-msgpack" | "x.msgpack") => Self::MsgPack,
 			#[cfg(feature = "bincode")]
@@ -162,6 +170,8 @@ impl ContentType {
 		match *self {
 			#[cfg(feature = "json")]
 			Self::Json => "application/json",
+			#[cfg(feature = "form")]
+			Self::Form => "application/x-www-form-urlencoded",
 			#[cfg(feature = "msgpack")]
 			Self::MsgPack => "application/vnd.msgpack",
 			#[cfg(feature = "bincode")]
@@ -277,9 +287,18 @@ where
 
 	async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
 		let header = None
-			.or_else(|| parts.headers.get(header::ACCEPT))
-			.or_else(|| parts.headers.get(header::CONTENT_TYPE))
-			.and_then(ContentType::from_header)
+			.or_else(|| {
+				parts
+					.headers
+					.get(header::ACCEPT)
+					.and_then(ContentType::from_header)
+			})
+			.or_else(|| {
+				parts
+					.headers
+					.get(header::CONTENT_TYPE)
+					.and_then(ContentType::from_header)
+			})
 			.unwrap_or_default();
 
 		Ok(Self(header))

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -24,6 +24,17 @@ where
 		serde_json::from_slice(bytes).map(Self)
 	}
 
+	/// Attempts to deserialize the given bytes as [URL-encoded form data](https://url.spec.whatwg.org/#urlencoded-parsing).
+	///
+	/// # Errors
+	///
+	/// See [`serde_urlencoded::from_bytes`].
+	#[cfg(feature = "form")]
+	#[inline]
+	pub fn from_form(bytes: &'b [u8]) -> Result<Self, serde_urlencoded::de::Error> {
+		serde_urlencoded::from_bytes(bytes).map(Self)
+	}
+
 	/// Attempts to deserialize the given bytes as [MessagePack](https://msgpack.org).
 	/// Does not perform any validation if the `validator` feature is enabled. For
 	/// validation, use [`Self::from_bytes`].
@@ -124,6 +135,8 @@ impl<'b, T> Codec<T> {
 		let codec = match content_type {
 			#[cfg(feature = "json")]
 			ContentType::Json => Self::from_json(bytes)?,
+			#[cfg(feature = "form")]
+			ContentType::Form => Self::from_form(bytes)?,
 			#[cfg(feature = "msgpack")]
 			ContentType::MsgPack => Self::from_msgpack(bytes)?,
 			#[cfg(feature = "bincode")]

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -20,6 +20,9 @@ pub enum Error {
 	#[cfg(feature = "json")]
 	#[error(transparent)]
 	Json(#[from] serde_json::Error),
+	#[cfg(feature = "form")]
+	#[error(transparent)]
+	Form(#[from] serde_urlencoded::ser::Error),
 	#[cfg(feature = "msgpack")]
 	#[error(transparent)]
 	MsgPack(#[from] rmp_serde::encode::Error),
@@ -62,6 +65,17 @@ where
 	#[inline]
 	pub fn to_json(&self) -> Result<Vec<u8>, serde_json::Error> {
 		serde_json::to_vec(&self.0)
+	}
+
+	/// Attempts to serialize the given value as [URL-encoded form data](https://url.spec.whatwg.org/#urlencoded-parsing).
+	///
+	/// # Errors
+	///
+	/// See [`serde_urlencoded::to_string`].
+	#[cfg(feature = "form")]
+	#[inline]
+	pub fn to_form(&self) -> Result<Vec<u8>, serde_urlencoded::ser::Error> {
+		serde_urlencoded::to_string(&self.0).map(String::into_bytes)
 	}
 
 	/// Attempts to serialize the given value as [MessagePack](https://msgpack.org).
@@ -152,6 +166,8 @@ impl<T> Codec<T> {
 		Ok(match content_type {
 			#[cfg(feature = "json")]
 			ContentType::Json => self.to_json()?,
+			#[cfg(feature = "form")]
+			ContentType::Form => self.to_form()?,
 			#[cfg(feature = "msgpack")]
 			ContentType::MsgPack => self.to_msgpack()?,
 			#[cfg(feature = "bincode")]

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -8,7 +8,7 @@ use axum::{
 	http::header,
 	response::{IntoResponse, Response},
 };
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 
 use crate::{Accept, CodecDecode, CodecEncode, CodecRejection, ContentType, IntoCodecResponse};
 
@@ -115,11 +115,22 @@ where
 			.and_then(ContentType::from_header)
 			.unwrap_or_default();
 
-		let bytes = BytesMut::from_request(req, state)
-			.await
-			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
-		let data =
-			Codec::from_bytes(&bytes, content_type).map_err(|e| e.into_codec_response(accept.into()))?;
+		let data = match () {
+			#[cfg(feature = "form")]
+			() if content_type == ContentType::Form && req.method() == axum::http::Method::GET => {
+				let query = req.uri().query().unwrap_or("");
+
+				Codec::from_form(query.as_bytes()).map_err(CodecRejection::from)
+			}
+			() => {
+				let bytes = Bytes::from_request(req, state)
+					.await
+					.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
+
+				Codec::from_bytes(&bytes, content_type)
+			}
+		}
+		.map_err(|e| e.into_codec_response(accept.into()))?;
 
 		Ok(data)
 	}
@@ -335,9 +346,15 @@ where
 			.and_then(ContentType::from_header)
 			.unwrap_or_default();
 
-		let bytes = BytesMut::from_request(req, state)
-			.await
-			.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?;
+		let bytes = match () {
+			#[cfg(feature = "form")]
+			() if content_type == ContentType::Form && req.method() == axum::http::Method::GET => {
+				req.uri().query().map_or_else(BytesMut::new, BytesMut::from)
+			}
+			() => BytesMut::from_request(req, state)
+				.await
+				.map_err(|e| CodecRejection::from(e).into_codec_response(accept.into()))?,
+		};
 
 		let data =
 			Self::from_bytes(bytes, content_type).map_err(|e| e.into_codec_response(accept.into()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ mod test {
 	struct Data {
 		string: String,
 		integer: i32,
-		array: Vec<i32>,
 		boolean: bool,
 	}
 
@@ -80,7 +79,6 @@ mod test {
 		Data {
 			string: "hello".into(),
 			integer: 42,
-			array: vec![1, 2, 3],
 			boolean: true,
 		}
 	}
@@ -129,6 +127,26 @@ mod test {
 		let encoded = Codec(&data).to_json().unwrap();
 
 		let Codec(decoded) = Codec::<BorrowedData>::from_json(&encoded).unwrap();
+
+		assert_eq!(decoded, data);
+	}
+
+	#[test]
+	fn test_form_roundtrip() {
+		let data = data();
+		let encoded = Codec(&data).to_form().unwrap();
+
+		let Codec(decoded) = Codec::<Data>::from_form(&encoded).unwrap();
+
+		assert_eq!(decoded, data);
+	}
+
+	#[test]
+	fn test_borrowed_form_roundtrip() {
+		let data = borrowed_data();
+		let encoded = Codec(&data).to_form().unwrap();
+
+		let Codec(decoded) = Codec::<BorrowedData>::from_form(&encoded).unwrap();
 
 		assert_eq!(decoded, data);
 	}

--- a/src/rejection.rs
+++ b/src/rejection.rs
@@ -14,6 +14,9 @@ pub enum CodecRejection {
 	#[cfg(feature = "json")]
 	#[error(transparent)]
 	Json(#[from] serde_json::Error),
+	#[cfg(feature = "form")]
+	#[error(transparent)]
+	Form(#[from] serde_urlencoded::de::Error),
 	#[cfg(feature = "msgpack")]
 	#[error(transparent)]
 	MsgPack(#[from] rmp_serde::decode::Error),
@@ -157,6 +160,8 @@ impl CodecRejection {
 			}
 			#[cfg(feature = "json")]
 			Self::Json(..) => "decode",
+			#[cfg(feature = "form")]
+			Self::Form(..) => "decode",
 			#[cfg(feature = "msgpack")]
 			Self::MsgPack(..) => "decode",
 			#[cfg(feature = "cbor")]


### PR DESCRIPTION
Adds support for `x-www-form-urlencoded` (both GET and POST variants, similar to axum's `Form`)