### PR TITLE
Switch from deprecated `serde_yaml` to supported fork `serde_yaml_ng`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml",
+ "serde_yaml_ng",
  "thiserror",
  "tokio",
  "toml",
@@ -1058,10 +1058,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ schemars = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 serde_json = { version = "1", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
-serde_yaml = { version = "0.9", optional = true }
+serde_yaml_ng = { version = "0.10", optional = true }
 thiserror = "2"
 toml = { version = "0.9", optional = true }
 validator = { version = "0.20", optional = true }
@@ -66,7 +66,7 @@ bitcode = ["dep:bitcode", "axum-codec-macros/bitcode"]
 json = ["dep:serde_json", "serde"]
 msgpack = ["dep:rmp-serde", "serde"]
 toml = ["dep:toml", "serde"]
-yaml = ["dep:serde_yaml", "serde"]
+yaml = ["dep:serde_yaml_ng", "serde"]
 
 # Should not be manually enabled, but will not cause any issues if it is.
 serde = ["dep:serde", "axum-codec-macros/serde"]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -69,11 +69,11 @@ where
 	///
 	/// # Errors
 	///
-	/// See [`serde_yaml::from_slice`].
+	/// See [`serde_yaml_ng::from_slice`].
 	#[cfg(feature = "yaml")]
 	#[inline]
-	pub fn from_yaml(text: &'b str) -> Result<Self, serde_yaml::Error> {
-		serde_yaml::from_str(text).map(Self)
+	pub fn from_yaml(text: &'b str) -> Result<Self, serde_yaml_ng::Error> {
+		serde_yaml_ng::from_str(text).map(Self)
 	}
 
 	/// Attempts to deserialize the given text as [TOML](https://toml.io).

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -34,7 +34,7 @@ pub enum Error {
 	Bincode(#[from] bincode::error::EncodeError),
 	#[cfg(feature = "yaml")]
 	#[error(transparent)]
-	Yaml(#[from] serde_yaml::Error),
+	Yaml(#[from] serde_yaml_ng::Error),
 	#[cfg(feature = "toml")]
 	#[error(transparent)]
 	Toml(#[from] toml::ser::Error),
@@ -106,11 +106,11 @@ where
 	///
 	/// # Errors
 	///
-	/// See [`serde_yaml::to_vec`].
+	/// See [`serde_yaml_ng::to_vec`].
 	#[cfg(feature = "yaml")]
 	#[inline]
-	pub fn to_yaml(&self) -> Result<String, serde_yaml::Error> {
-		serde_yaml::to_string(&self.0)
+	pub fn to_yaml(&self) -> Result<String, serde_yaml_ng::Error> {
+		serde_yaml_ng::to_string(&self.0)
 	}
 
 	/// Attempts to serialize the given value as [TOML](https://toml.io).

--- a/src/rejection.rs
+++ b/src/rejection.rs
@@ -31,7 +31,7 @@ pub enum CodecRejection {
 	Bitcode(#[from] bitcode::Error),
 	#[cfg(feature = "yaml")]
 	#[error(transparent)]
-	Yaml(#[from] serde_yaml::Error),
+	Yaml(#[from] serde_yaml_ng::Error),
 	#[cfg(feature = "toml")]
 	#[error(transparent)]
 	Toml(#[from] toml::de::Error),


### PR DESCRIPTION
The widely used [serde_yaml](https://crates.io/crates/serde_yaml) package is deprecated and no longer maintained.

A fork which is still maintained is [serde_yaml_ng](https://github.com/acatton/serde-yaml-ng), which promises backwards compatibility with the old library.

## Caveats
* The topic of which yaml library to move to is still widely debated in the rust community, eg: https://users.rust-lang.org/t/serde-yaml-deprecation-alternatives/108868
* The library I've picked has 80 stars on github, which is a decent number, but pales into comparison of the 1000 stars of the previous library
* I'm very new to writing rust (only really started yesterday), so don't take my word on the best way forward.