### PR TITLE
Content Negotiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "accept-header"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d9100fb78aa3b854faf01fd9f65f7d1805c47f0f2720919a4120b0a4be0dd83"
+dependencies = [
+ "http 0.2.12",
+ "itertools",
+ "mime",
+ "snafu",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,7 +47,7 @@ dependencies = [
  "axum",
  "bytes",
  "cfg-if",
- "http",
+ "http 1.3.1",
  "indexmap",
  "schemars",
  "serde",
@@ -86,7 +98,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -114,6 +126,7 @@ dependencies = [
 name = "axum-codec"
 version = "0.0.20"
 dependencies = [
+ "accept-header",
  "aide",
  "axum",
  "axum-codec",
@@ -141,7 +154,7 @@ version = "0.0.13"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -152,7 +165,7 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "mime",
@@ -230,7 +243,7 @@ checksum = "ffebfc2d28a12b262c303cb3860ee77b91bd83b1f20f0bd2a9693008e2f55a9e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -317,7 +330,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -328,7 +341,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -339,14 +352,26 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -425,7 +450,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -487,6 +512,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -515,7 +557,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.3.1",
  "http-body",
  "pin-project-lite",
 ]
@@ -542,7 +584,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
+ "http 1.3.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -561,7 +603,7 @@ checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.3.1",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -706,6 +748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,7 +894,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -955,7 +1006,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -985,7 +1036,7 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -996,7 +1047,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1083,6 +1134,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1176,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1129,7 +1213,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1149,7 +1233,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1198,7 +1282,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1288,7 +1372,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1363,7 +1447,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1483,7 +1567,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -1504,7 +1588,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -1538,5 +1622,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ all-features = true
 members = ["macros", ".", "examples/*"]
 
 [dependencies]
+accept-header = "0.2.3"
 aide = { version = "0.14", optional = true, default-features = false, features = ["axum", "axum-json"] }
 axum = { version = "0.8", default-features = false }
 axum-codec-macros = { path = "macros", version = "0.0.13", default-features = false }

--- a/src/content.rs
+++ b/src/content.rs
@@ -106,52 +106,24 @@ impl FromStr for ContentType {
 		// Prepare a list of supported media types, based on which features are enabled
 		let mut available = Vec::new();
 		#[cfg(feature = "json")]
-		available.push(mime::Mime::from_str("application/json").unwrap());
+		available.push("application/json");
 		#[cfg(feature = "form")]
-		available.push(mime::Mime::from_str("application/x-www-form-urlencoded").unwrap());
+		available.push("application/x-www-form-urlencoded");
 		#[cfg(feature = "msgpack")]
-		available.extend([
-			mime::Mime::from_str("application/msgpack").unwrap(),
-			mime::Mime::from_str("application/vnd.msgpack").unwrap(),
-			mime::Mime::from_str("application/x-msgpack").unwrap(),
-			mime::Mime::from_str("application/x.msgpack").unwrap(),
-		]);
+		available.extend([ "application/msgpack", "application/vnd.msgpack", "application/x-msgpack", "application/x.msgpack"]);
 		#[cfg(feature = "bincode")]
-		available.extend([
-			mime::Mime::from_str("application/bincode").unwrap(),
-			mime::Mime::from_str("application/vnd.bincode").unwrap(),
-			mime::Mime::from_str("application/x-bincode").unwrap(),
-			mime::Mime::from_str("application/x.bincode").unwrap(),
-		]);
+		available.extend([ "application/bincode", "application/vnd.bincode", "application/x-bincode", "application/x.bincode"]);
 		#[cfg(feature = "bitcode")]
-		available.extend([
-			mime::Mime::from_str("application/bitcode").unwrap(),
-			mime::Mime::from_str("application/vnd.bitcode").unwrap(),
-			mime::Mime::from_str("application/x-bitcode").unwrap(),
-			mime::Mime::from_str("application/x.bitcode").unwrap(),
-		]);
+		available.extend([ "application/bitcode", "application/vnd.bitcode", "application/x-bitcode", "application/x.bitcode"]);
 		#[cfg(feature = "cbor")]
-		available.push(mime::Mime::from_str("application/cbor").unwrap());
+		available.push("application/cbor");
 		#[cfg(feature = "yaml")]
-		available.extend([
-			mime::Mime::from_str("application/yaml").unwrap(),
-			mime::Mime::from_str("application/yml").unwrap(),
-			mime::Mime::from_str("application/x-yaml").unwrap(),
-			mime::Mime::from_str("text/yaml").unwrap(),
-			mime::Mime::from_str("text/yml").unwrap(),
-			mime::Mime::from_str("text/x-yaml").unwrap(),
-		]);
+		available.extend([ "application/yaml", "application/yml", "application/x-yaml", "text/yaml", "text/yml", "text/x-yaml"]);
 		#[cfg(feature = "toml")]
-		available.extend([
-			mime::Mime::from_str("application/toml").unwrap(),
-			mime::Mime::from_str("application/x-toml").unwrap(),
-			mime::Mime::from_str("application/vnd.toml").unwrap(),
-			mime::Mime::from_str("text/toml").unwrap(),
-			mime::Mime::from_str("text/x-toml").unwrap(),
-			mime::Mime::from_str("text/vnd.toml").unwrap(),
-		]);
+		available.extend([ "application/toml", "application/x-toml", "application/vnd.toml", "text/toml", "text/x-toml", "text/vnd.toml"]);
 
-		let mime = accept.negotiate(&available).map_err(|_| FromStrError::InvalidContentType)?;
+		let available_mimes: Vec<mime::Mime> = available.into_iter().map(|string| mime::Mime::from_str(string).unwrap()).collect();
+		let mime = accept.negotiate(&available_mimes).map_err(|_| FromStrError::InvalidContentType)?;
 		let subtype = mime.suffix().unwrap_or_else(|| mime.subtype());
 
 		Ok(match (mime.type_().as_str(), subtype.as_str()) {

--- a/src/content.rs
+++ b/src/content.rs
@@ -100,7 +100,58 @@ impl FromStr for ContentType {
 	type Err = FromStrError;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		let mime = s.parse::<mime::Mime>()?;
+
+		let accept: accept_header::Accept = s.parse().map_err(|_| FromStrError::InvalidContentType)?;
+
+		// Prepare a list of supported media types, based on which features are enabled
+		let mut available = Vec::new();
+		#[cfg(feature = "json")]
+		available.push(mime::Mime::from_str("application/json").unwrap());
+		#[cfg(feature = "form")]
+		available.push(mime::Mime::from_str("application/x-www-form-urlencoded").unwrap());
+		#[cfg(feature = "msgpack")]
+		available.extend([
+			mime::Mime::from_str("application/msgpack").unwrap(),
+			mime::Mime::from_str("application/vnd.msgpack").unwrap(),
+			mime::Mime::from_str("application/x-msgpack").unwrap(),
+			mime::Mime::from_str("application/x.msgpack").unwrap(),
+		]);
+		#[cfg(feature = "bincode")]
+		available.extend([
+			mime::Mime::from_str("application/bincode").unwrap(),
+			mime::Mime::from_str("application/vnd.bincode").unwrap(),
+			mime::Mime::from_str("application/x-bincode").unwrap(),
+			mime::Mime::from_str("application/x.bincode").unwrap(),
+		]);
+		#[cfg(feature = "bitcode")]
+		available.extend([
+			mime::Mime::from_str("application/bitcode").unwrap(),
+			mime::Mime::from_str("application/vnd.bitcode").unwrap(),
+			mime::Mime::from_str("application/x-bitcode").unwrap(),
+			mime::Mime::from_str("application/x.bitcode").unwrap(),
+		]);
+		#[cfg(feature = "cbor")]
+		available.push(mime::Mime::from_str("application/cbor").unwrap());
+		#[cfg(feature = "yaml")]
+		available.extend([
+			mime::Mime::from_str("application/yaml").unwrap(),
+			mime::Mime::from_str("application/yml").unwrap(),
+			mime::Mime::from_str("application/x-yaml").unwrap(),
+			mime::Mime::from_str("text/yaml").unwrap(),
+			mime::Mime::from_str("text/yml").unwrap(),
+			mime::Mime::from_str("text/x-yaml").unwrap(),
+		]);
+		#[cfg(feature = "toml")]
+		available.extend([
+			mime::Mime::from_str("application/toml").unwrap(),
+			mime::Mime::from_str("application/x-toml").unwrap(),
+			mime::Mime::from_str("application/vnd.toml").unwrap(),
+			mime::Mime::from_str("text/toml").unwrap(),
+			mime::Mime::from_str("text/x-toml").unwrap(),
+			mime::Mime::from_str("text/vnd.toml").unwrap(),
+		]);
+
+		let mime = accept.negotiate(&available).map_err(|_| FromStrError::InvalidContentType)?;
 		let subtype = mime.suffix().unwrap_or_else(|| mime.subtype());
 
 		Ok(match (mime.type_().as_str(), subtype.as_str()) {
@@ -151,6 +202,26 @@ impl ContentType {
 	/// let content_type = ContentType::from_header(&header).unwrap();
 	///
 	/// assert_eq!(content_type, ContentType::MsgPack);
+	///
+	/// let header = HeaderValue::from_static("text/plain, image/png, application/x-yaml, application/json");
+	/// let content_type = ContentType::from_header(&header).unwrap();
+	///
+	/// assert_eq!(content_type, ContentType::Yaml);
+	///
+	/// let header = HeaderValue::from_static("application/x-msgpack;q=0.7, application/json;q=0.6");
+	/// let content_type = ContentType::from_header(&header).unwrap();
+	///
+	/// assert_eq!(content_type, ContentType::MsgPack);
+	///
+	/// let header = HeaderValue::from_static("text/plain, image/png, unknown/*");
+	/// let option = ContentType::from_header(&header);
+	///
+	/// assert_eq!(option, None);
+	///
+	/// let header = HeaderValue::from_static("");
+	/// let option = ContentType::from_header(&header);
+	///
+	/// assert_eq!(option, None);
 	/// # }
 	pub fn from_header(header: &HeaderValue) -> Option<Self> {
 		header.to_str().ok()?.parse().ok()


### PR DESCRIPTION
Currently, (as far as I understand), axum-codec only works with `Accept` headers which contain a single mime type, and provide no relative weights.  That means only a small subset of the full range of Accept headers supported by the HTTP spec ([rfc7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2)) will work with it.

This PR attempts to support full content negotiation of `Accept` headers, including relative weights.  To do this, it relies heavily on a pre-existing crate, [accept-header](https://crates.io/crates/accept-header), rather than adding all the parsing logic here.

I'm very new to rust (started writing it yesterday), so I've probably made this much more verbose than it needs to be.  Would appreciate any input from more experienced rustaceans.